### PR TITLE
AprioriTID Extension

### DIFF
--- a/crates/apriori/src/apriori.rs
+++ b/crates/apriori/src/apriori.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::HashSet,
-    ops::{Deref, DerefMut},
-};
+use std::ops::{Deref, DerefMut};
 
 use datasets::{transaction_set::TransactionSet, utils::nested_loops};
 
@@ -85,7 +82,13 @@ impl<T: Deref<Target = CandidateType>> AprioriCandidates<T> {
                 combinations /= (2..(t.len() - i + 1).min(i + 1)).product::<usize>();
             }
             if tree.len() > combinations {
-                nested_loops(|v| tree.increment(v), &data.transactions[idx], i);
+                nested_loops(
+                    |v| {
+                        tree.increment(v);
+                    },
+                    &data.transactions[idx],
+                    i,
+                );
             } else {
                 tree.for_each_mut(|v, n| {
                     if v.iter().all(|a| t.contains(a)) {

--- a/crates/apriori/src/hash_tree.rs
+++ b/crates/apriori/src/hash_tree.rs
@@ -203,14 +203,10 @@ struct HashTreeInternalNode<const N: usize> {
 impl<const N: usize> HashTreeInternalNode<N> {
     fn for_each_mut(&mut self, f: &mut impl FnMut(&[usize], &mut u64)) {
         for n in &mut self.map {
-            match n {
-                Some(n) => match &mut **n {
-                    Node::Internal(hash_tree_internal_node) => {
-                        hash_tree_internal_node.for_each_mut(f)
-                    }
-                    Node::Leaf(hash_tree_leaf_node) => hash_tree_leaf_node.for_each_mut(f),
-                },
-                None => (),
+            let Some(n) = n else { continue };
+            match &mut **n {
+                Node::Internal(hash_tree_internal_node) => hash_tree_internal_node.for_each_mut(f),
+                Node::Leaf(hash_tree_leaf_node) => hash_tree_leaf_node.for_each_mut(f),
             }
         }
     }

--- a/crates/apriori/src/transaction_id.rs
+++ b/crates/apriori/src/transaction_id.rs
@@ -1,14 +1,10 @@
-use std::{
-    collections::{HashMap, HashSet},
-    ops::DerefMut,
-};
+use std::collections::{HashMap, HashSet};
 
 use datasets::{transaction_set::TransactionSet, utils::nested_loops};
 
-use crate::{
-    candidates_func::join,
-    hash_tree::{AprioriHashTree, AprioriHashTreeGeneric},
-};
+use crate::
+    candidates_func::join
+;
 #[derive(Debug, Default)]
 pub struct TransactionIDs {
     v: Vec<TransactionID>,
@@ -73,6 +69,16 @@ impl TransactionID {
         Self { v }
     }
 
+    pub fn count_with_next<T: TransactionIdCounts>(&self, set: &mut T) -> Self {
+        let mut o = TransactionID::default();
+        join(&self.v.iter().collect::<Vec<_>>(), |curr| {
+            if set.increment(&curr) {
+                o.v.insert(curr);
+            }
+        });
+        o
+    }
+
     pub fn count<T: TransactionIdCounts>(&self, set: &mut T) {
         join(&self.v.iter().collect::<Vec<_>>(), |curr| {
             set.increment(&curr);
@@ -123,23 +129,16 @@ impl TransactionID {
 }
 
 pub trait TransactionIdCounts {
-    fn increment(&mut self, v: &[usize]);
+    fn increment(&mut self, v: &[usize]) -> bool;
 }
 impl TransactionIdCounts for HashMap<Vec<usize>, u64> {
-    fn increment(&mut self, v: &[usize]) {
+    fn increment(&mut self, v: &[usize]) -> bool {
         if let Some(a) = self.get_mut(v) {
-            *a += 1
+            *a += 1;
+            true
+        } else {
+            false
         }
-    }
-}
-impl<const N: usize> TransactionIdCounts for AprioriHashTreeGeneric<N> {
-    fn increment(&mut self, v: &[usize]) {
-        self.increment(v);
-    }
-}
-impl TransactionIdCounts for AprioriHashTree {
-    fn increment(&mut self, v: &[usize]) {
-        self.deref_mut().increment(v);
     }
 }
 

--- a/crates/apriori/src/transaction_id.rs
+++ b/crates/apriori/src/transaction_id.rs
@@ -14,6 +14,14 @@ impl TransactionIDs {
     pub fn new(v: Vec<TransactionID>) -> Self {
         Self { v }
     }
+    pub fn count_with_next<T: TransactionIdCounts>(&self, set: &mut T) -> Self {
+        let mut o = Self::default();
+        for d in &self.v {
+            let a = d.count_with_next(set);
+            o.v.push(a);
+        }
+        o
+    }
     pub fn count<T: TransactionIdCounts>(&self, set: &mut T) {
         for d in &self.v {
             d.count(set);


### PR DESCRIPTION
Adds another way to run TID with the TIDs being built during counting instead of after.  It is slower in my limited testing.